### PR TITLE
Log errors at the end of the command

### DIFF
--- a/src/PendingObjects/PendingError.php
+++ b/src/PendingObjects/PendingError.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Imanghafoori\LaravelMicroscope\PendingObjects;
+
+class PendingError
+{
+    private $type;
+    private $header;
+    private $errorData;
+    private $linkPath;
+    private $linkLineNumber = 4;
+
+    /**
+     * PendingError constructor.
+     *
+     * @param $type
+     */
+    function __construct($type)
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * Sets the content of the error header.
+     *
+     * @param  string  $header
+     *
+     * @return $this
+     */
+    public function header(string $header)
+    {
+        $this->header = $header;
+
+        return $this;
+    }
+
+    /**
+     * Sets the data to give out as error.
+     *
+     * @param $data
+     *
+     * @return $this
+     */
+    public function errorData($data)
+    {
+        $this->errorData = $data;
+
+        return $this;
+    }
+
+    /**
+     * Sets the link to the source error.
+     * @param $path
+     * @param  int  $linenumber
+     *
+     * @return $this
+     */
+    public function link($path, $linenumber = 4)
+    {
+        $this->linkPath = $path;
+        $this->linkLineNumber = $linenumber;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getHeader()
+    {
+        return $this->header;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getErrorData()
+    {
+        return $this->errorData;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getLinkPath()
+    {
+        return $this->linkPath;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLinkLineNumber(): int
+    {
+        return $this->linkLineNumber;
+    }
+}

--- a/src/Traits/LogsErrors.php
+++ b/src/Traits/LogsErrors.php
@@ -20,6 +20,7 @@ trait LogsErrors
 
         if ($errorCount = $errorPrinter->hasErrors()) {
             $this->error($errorCount.' errors found for '.$commandType);
+            $errorPrinter->logErrors();
         } else {
             $this->info('All '.$commandType.' are correct!');
         }


### PR DESCRIPTION
Just a little refactor of the error system. Currently the package shows the error when the command is running.

This PR adds the errors and show them at the end of the command run.

![Screenshot from 2020-04-09 23-31-05](https://user-images.githubusercontent.com/12772919/78942688-7abe0280-7aba-11ea-8382-34a02492008a.png)

Before this PR the number of errors is shown after the table of errors. Now it logs the number before showing the error info in detail.

I think logging them at the end helps if we are to do some other staff like showing progress on the terminal without errors popping in the middle of the process