### PR TITLE
Command progress

### DIFF
--- a/src/CheckClasses.php
+++ b/src/CheckClasses.php
@@ -3,6 +3,7 @@
 namespace Imanghafoori\LaravelMicroscope;
 
 use Illuminate\Support\Str;
+use Imanghafoori\LaravelMicroscope\Contracts\FileCheckContract;
 use ReflectionClass;
 use ReflectionException;
 use Symfony\Component\Finder\Finder;
@@ -20,11 +21,17 @@ class CheckClasses
      * @param $composerPath
      * @param $composerNamespace
      *
+     * @param  FileCheckContract  $fileCheckContract
+     *
      * @return void
      */
-    public static function checkImports($files, $basePath, $composerPath, $composerNamespace)
+    public static function checkImports($files, $basePath, $composerPath, $composerNamespace, FileCheckContract $fileCheckContract)
     {
         foreach ($files as $classFilePath) {
+
+            if($fileCheckContract)
+                $fileCheckContract->onFileTap($classFilePath);
+
             $absFilePath = $classFilePath->getRealPath();
 
             if (! self::hasOpeningTag($absFilePath)) {

--- a/src/CheckClasses.php
+++ b/src/CheckClasses.php
@@ -87,16 +87,19 @@ class CheckClasses
      * Get all of the listeners and their corresponding events.
      *
      * @param  iterable  $paths
-     * @param  string  $basePath
-     *
      * @param $composerPath
      * @param $composerNamespace
      *
+     * @param  FileCheckContract  $fileCheckContract
+     *
      * @return void
      */
-    public static function checkAllClasses($paths, $composerPath, $composerNamespace)
+    public static function checkAllClasses($paths, $composerPath, $composerNamespace, FileCheckContract $fileCheckContract)
     {
         foreach ($paths as $classFilePath) {
+            if($fileCheckContract)
+                $fileCheckContract->onFileTap($classFilePath);
+
             $absFilePath = $classFilePath->getRealPath();
 
             // exclude blade files

--- a/src/Commands/CheckImports.php
+++ b/src/Commands/CheckImports.php
@@ -7,19 +7,23 @@ use Illuminate\Database\Eloquent\Model;
 use Imanghafoori\LaravelMicroscope\CheckClasses;
 use Imanghafoori\LaravelMicroscope\Checks\CheckClassReferences;
 use Imanghafoori\LaravelMicroscope\CheckViewRoute;
+use Imanghafoori\LaravelMicroscope\Contracts\FileCheckContract;
 use Imanghafoori\LaravelMicroscope\ErrorPrinter;
 use Imanghafoori\LaravelMicroscope\Traits\LogsErrors;
+use Imanghafoori\LaravelMicroscope\Traits\ScansFiles;
 use Imanghafoori\LaravelMicroscope\Util;
 
-class CheckImports extends Command
+class CheckImports extends Command implements FileCheckContract
 {
     use LogsErrors;
+    use ScansFiles;
+
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'check:imports';
+    protected $signature = 'check:imports {--d|detailed : Show files being checked}';
 
     /**
      * The console command description.
@@ -45,7 +49,7 @@ class CheckImports extends Command
 
         foreach ($psr4 as $psr4Namespace => $psr4Path) {
             $files = CheckClasses::getAllPhpFiles($psr4Path);
-            CheckClasses::checkImports($files, base_path(), $psr4Path, $psr4Namespace);
+            CheckClasses::checkImports($files, base_path(), $psr4Path, $psr4Namespace, $this);
         }
 
         (new CheckViewRoute)->check([

--- a/src/Commands/CheckPsr4.php
+++ b/src/Commands/CheckPsr4.php
@@ -4,19 +4,22 @@ namespace Imanghafoori\LaravelMicroscope\Commands;
 
 use Illuminate\Console\Command;
 use Imanghafoori\LaravelMicroscope\CheckClasses;
+use Imanghafoori\LaravelMicroscope\Contracts\FileCheckContract;
 use Imanghafoori\LaravelMicroscope\ErrorPrinter;
 use Imanghafoori\LaravelMicroscope\Traits\LogsErrors;
+use Imanghafoori\LaravelMicroscope\Traits\ScansFiles;
 use Imanghafoori\LaravelMicroscope\Util;
 
-class CheckPsr4 extends Command
+class CheckPsr4 extends Command implements FileCheckContract
 {
     use LogsErrors;
+    use ScansFiles;
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'check:psr4';
+    protected $signature = 'check:psr4 {--d|detailed : Show files being checked}';
 
     /**
      * The console command description.
@@ -42,7 +45,7 @@ class CheckPsr4 extends Command
 
         foreach ($psr4 as $psr4Namespace => $psr4Path) {
             $files = CheckClasses::getAllPhpFiles($psr4Path);
-            CheckClasses::checkAllClasses($files, $psr4Path, $psr4Namespace);
+            CheckClasses::checkAllClasses($files, $psr4Path, $psr4Namespace, $this);
         }
 
         $this->finishCommand($errorPrinter);

--- a/src/Commands/CheckRoutes.php
+++ b/src/Commands/CheckRoutes.php
@@ -40,7 +40,14 @@ class CheckRoutes extends Command
         $errorPrinter->printer = $this->output;
 
         $routes = app(Router::class)->getRoutes()->getRoutes();
+
+        $bar = $this->output->createProgressBar(count($routes));
+
+        $bar->start();
+
         foreach ($routes as $route) {
+            $bar->advance();
+
             if (! is_string($ctrl = $route->getAction()['uses'])) {
                 continue;
             }
@@ -66,6 +73,8 @@ class CheckRoutes extends Command
                 $errorPrinter->route($ctrl, $errorIt, $errorCtrl);
             }
         }
+
+        $bar->finish();
 
         $this->finishCommand($errorPrinter);
     }

--- a/src/Contracts/FileCheckContract.php
+++ b/src/Contracts/FileCheckContract.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Imanghafoori\LaravelMicroscope\Contracts;
+
+interface FileCheckContract
+{
+    /**
+     * Called when working on a file.
+     *
+     * @param $file
+     *
+     * @return mixed
+     */
+    function onFileTap($file);
+}

--- a/src/Traits/LogsErrors.php
+++ b/src/Traits/LogsErrors.php
@@ -19,10 +19,10 @@ trait LogsErrors
         $commandType = strtolower($commandType);
 
         if ($errorCount = $errorPrinter->hasErrors()) {
-            $this->error($errorCount.' errors found for '.$commandType);
+            $this->error(PHP_EOL .$errorCount.' errors found for '.$commandType);
             $errorPrinter->logErrors();
         } else {
-            $this->info('All '.$commandType.' are correct!');
+            $this->info(PHP_EOL .'All '.$commandType.' are correct!');
         }
     }
 }

--- a/src/Traits/ScansFiles.php
+++ b/src/Traits/ScansFiles.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Imanghafoori\LaravelMicroscope\Traits;
+
+trait ScansFiles
+{
+
+    /**
+     * @inheritDoc
+     */
+    function onFileTap($file)
+    {
+        if ($this->option('detailed')) {
+            $this->line("Checking {$file->getRelativePathname()}");
+        }
+    }
+}


### PR DESCRIPTION
So i added the `--verbose` option but its taken by Laravel by default.

Rather i chose `--d|detailed `

`php artisan check:imports -d` for example.

The `check:routes` is using a progress bar though