### PR TITLE
Aligned command description format & tweaked wording

### DIFF
--- a/src/Commands/CheckActionComments.php
+++ b/src/Commands/CheckActionComments.php
@@ -14,7 +14,7 @@ class CheckActionComments extends Command
 
     protected $signature = 'check:action_comments';
 
-    protected $description = 'Adds route definition to the controller actions.';
+    protected $description = 'Adds route definition to the controller actions';
 
     public function handle(ErrorPrinter $errorPrinter)
     {

--- a/src/Commands/CheckAll.php
+++ b/src/Commands/CheckAll.php
@@ -13,7 +13,7 @@ class CheckAll extends Command
 
     protected $signature = 'check:all {--d|detailed : Show files being checked} {--f|force}';
 
-    protected $description = 'Run all checks with one command.';
+    protected $description = 'Run all checks with one command';
 
     public function handle(ErrorPrinter $errorPrinter)
     {
@@ -43,7 +43,7 @@ class CheckAll extends Command
         if (random_int(1, 2) == 2 && Str::startsWith(request()->server('argv')[1] ?? '', 'check:al')) {
             $this->info(PHP_EOL.'Heyman, If you find this package useful to you...');
             $this->info('Please contribute to it by sharing a post about it or give it an star on github.');
-            $this->info('Reguards, Iman Ghafoori   (^_^) ');
+            $this->info('Regards, Iman Ghafoori   (^_^) ');
             $this->info('https://github.com/imanghafoori1/microscope');
         }
 

--- a/src/Commands/CheckBadPractice.php
+++ b/src/Commands/CheckBadPractice.php
@@ -16,7 +16,7 @@ class CheckBadPractice extends Command
 {
     protected $signature = 'check:bad_practices';
 
-    protected $description = 'Checks the bad practices';
+    protected $description = 'Checks for bad practices';
 
     public function handle()
     {

--- a/src/Commands/CheckCompact.php
+++ b/src/Commands/CheckCompact.php
@@ -15,7 +15,7 @@ class CheckCompact extends Command
 {
     protected $signature = 'check:compact';
 
-    protected $description = 'Checks the compact() function calls to be correct';
+    protected $description = 'Checks that compact() function calls are correct';
 
     public function handle()
     {

--- a/src/Commands/CheckDeadControllers.php
+++ b/src/Commands/CheckDeadControllers.php
@@ -14,7 +14,7 @@ class CheckDeadControllers extends Command
 
     protected $signature = 'check:dead_controllers';
 
-    protected $description = 'Checks public controller methods to have routes.';
+    protected $description = 'Checks that public controller methods have routes';
 
     public function handle(ErrorPrinter $errorPrinter)
     {

--- a/src/Commands/CheckEarlyReturns.php
+++ b/src/Commands/CheckEarlyReturns.php
@@ -12,7 +12,7 @@ class CheckEarlyReturns extends Command
 {
     protected $signature = 'check:early_returns {--t|test : backup the changed files}';
 
-    protected $description = 'Applies the early return on the classes.';
+    protected $description = 'Applies the early return on the classes';
 
     public function handle()
     {

--- a/src/Commands/CheckGenericActionComments.php
+++ b/src/Commands/CheckGenericActionComments.php
@@ -14,7 +14,7 @@ class CheckGenericActionComments extends Command
 
     protected $signature = 'check:docblocks';
 
-    protected $description = 'removes generic docblocks from controllers.';
+    protected $description = 'Removes generic docblocks from controllers';
 
     public function handle(ErrorPrinter $errorPrinter)
     {

--- a/src/Commands/CheckPsr12.php
+++ b/src/Commands/CheckPsr12.php
@@ -15,7 +15,7 @@ class CheckPsr12 extends Command
 
     protected $signature = 'check:psr12';
 
-    protected $description = 'applies psr-12 rules.';
+    protected $description = 'Applies psr-12 rules';
 
     public function handle(ErrorPrinter $errorPrinter)
     {

--- a/src/Commands/ClassifyStrings.php
+++ b/src/Commands/ClassifyStrings.php
@@ -14,7 +14,7 @@ class ClassifyStrings extends Command
 
     protected $signature = 'check:stringy_classes';
 
-    protected $description = 'Replaces string references with ::class version of them.';
+    protected $description = 'Replaces string references with ::class version of them';
 
     public function handle(ErrorPrinter $errorPrinter)
     {


### PR DESCRIPTION
Just something I noticed while testing this package. This PR aligns the descriptions so that they all start with a capital and do not end with a full-stop. Since some did have a full-stop before, I followed the default Laravel commands for guidance and removed any full stops to align.  I also updated the wording in a few cases.

I did also spot on [this line](https://github.com/imanghafoori1/laravel-microscope/blob/master/src/Commands/CheckAll.php#L44) you have "Heyman". I did not touch this just in case it's a personal greeting you like to use but this is commonly two words "Hey Man!", although, if you were to change this I'd advise maybe going with "Hey there!" just to be non-gender specific.

### Before

```
 check:action_comments   Adds route definition to the controller actions.
  check:all               Run all checks with one command.
  check:bad_practices     Checks the bad practices
  check:blade_queries     Checks db queries in blade files
  check:compact           Checks the compact() function calls to be correct
  check:dd                Checks the debug functions
  check:dead_controllers  Checks public controller methods to have routes.
  check:docblocks         removes generic docblocks from controllers.
  check:early_returns     Applies the early return on the classes.
  check:events            Checks the validity of event listeners
  check:extract_blades    Checks to extract blade partials
  check:gates             Checks the validity of gate definitions
  check:generate          Generates code
  check:imports           Checks the validity of use statements
  check:psr12             applies psr-12 rules.
  check:psr4              Checks the validity of namespaces
  check:routes            Checks the validity of route definitions
  check:stringy_classes   Replaces string references with ::class version of them.
  check:views             Checks the validity of blade files
```

### After

```
Available commands for the "check" namespace:
  check:action_comments   Adds route definition to the controller actions
  check:all               Run all checks with one command
  check:bad_practices     Checks for bad practices
  check:blade_queries     Checks db queries in blade files
  check:compact           Checks that compact() function calls are correct
  check:dd                Checks the debug functions
  check:dead_controllers  Checks that public controller methods have routes
  check:docblocks         Removes generic docblocks from controllers
  check:early_returns     Applies the early return on the classes
  check:events            Checks the validity of event listeners
  check:extract_blades    Checks to extract blade partials
  check:gates             Checks the validity of gate definitions
  check:generate          Generates code
  check:imports           Checks the validity of use statements
  check:psr12             Applies psr-12 rules
  check:psr4              Checks the validity of namespaces
  check:routes            Checks the validity of route definitions
  check:stringy_classes   Replaces string references with ::class version of them
  check:views             Checks the validity of blade files
```

### Package Feedback

This package looks really useful! Seems to cover a lot of common cases I'd often make (As you have seen in your PR). Something to note, Personally I was a bit surprised to run commands that start with `check:` and see them make changes. "Check", as a word, very much indicates that something will be reviewed/inspected but it does not infer further action in itself.  Personally I think it may be a nicer experience if all commands would only report/inspect by default but, where applicable, allow a `--fix` flag to actually make any changes.  Just my opinion though. 