### PR TITLE
rename command type to have succint message

### DIFF
--- a/src/Commands/CheckAll.php
+++ b/src/Commands/CheckAll.php
@@ -15,6 +15,8 @@ class CheckAll extends Command
 
     protected $description = 'Run all checks with one command';
 
+    protected $commandType = 'checks';
+
     public function handle(ErrorPrinter $errorPrinter)
     {
         $t1 = microtime(true);

--- a/src/Traits/LogsErrors.php
+++ b/src/Traits/LogsErrors.php
@@ -16,7 +16,7 @@ trait LogsErrors
     {
         $commandName = class_basename($this);
         $commandType = Str::after($commandName, 'Check');
-        $commandType = strtolower($commandType);
+        $commandType = $this->commandType ?? strtolower($commandType);
 
         if (! $errorPrinter->logErrors) {
             return;

--- a/src/Traits/LogsErrors.php
+++ b/src/Traits/LogsErrors.php
@@ -18,6 +18,10 @@ trait LogsErrors
         $commandType = Str::after($commandName, 'Check');
         $commandType = strtolower($commandType);
 
+        if (Str::is('all', $commandType)) {
+            $commandType = 'checks';
+        }
+
         if (! $errorPrinter->logErrors) {
             return;
         }

--- a/src/Traits/LogsErrors.php
+++ b/src/Traits/LogsErrors.php
@@ -18,10 +18,6 @@ trait LogsErrors
         $commandType = Str::after($commandName, 'Check');
         $commandType = strtolower($commandType);
 
-        if (Str::is('all', $commandType)) {
-            $commandType = 'checks';
-        }
-
         if (! $errorPrinter->logErrors) {
             return;
         }


### PR DESCRIPTION
when running check:all

**before**:
All all are correct!

**after**:
All checks are correct!