### PR TITLE
bug fix: bug in reading composer when we doesnt have key {type} in repsitory  part

### DIFF
--- a/src/Analyzers/ComposerJson.php
+++ b/src/Analyzers/ComposerJson.php
@@ -35,7 +35,7 @@ class ComposerJson
     {
         $composers = [];
         foreach (self::readKey('repositories') as $repo) {
-            if ($repo['type'] == 'path') {
+            if (isset($repo['type']) && $repo['type'] == 'path') {
                 // here we exclude local packages outside of the root folder.
                 ! Str::contains($repo['url'], '../') && $composers[] = \trim(\trim($repo['url'], '.'), '/').DIRECTORY_SEPARATOR.'';
             }


### PR DESCRIPTION
when we have some like below in composer.json
`"repositories": [
        {
            "packagist.org": false
        },
        {
            "type": "composer",
            "url": "https://packagist.com/"
        }
    ],`

we got an error type that doesn't define, we should check it