### PR TITLE
add some cluse in excludeMethods for envolving database rule validation

### DIFF
--- a/src/Commands/CheckDynamicWhereMethod.php
+++ b/src/Commands/CheckDynamicWhereMethod.php
@@ -56,6 +56,7 @@ class CheckDynamicWhereMethod extends Command
         'whereJsonDoesntContain',
         'whereJsonLength',
         'whereFullText',
+        'whereNot',
     ];
 
     public function handle(ErrorPrinter $errorPrinter)


### PR DESCRIPTION
involve `whereNot` cluse in excludeMethods array that is in DatabaseRule Validation

`vendor/laravel/framework/src/Illuminate/Validation/Rules/DatabaseRule.php`