### PR TITLE
fix error undefined array key 0 for search_replace command

### DIFF
--- a/src/SearchReplace/CheckRefactorsCommand.php
+++ b/src/SearchReplace/CheckRefactorsCommand.php
@@ -48,7 +48,12 @@ class CheckRefactorsCommand extends Command
         $patterns = $this->normalizePatterns($patterns);
         $parsedPatterns = PatternParser::parsePatterns($patterns);
 
-        ForPsr4LoadedClasses::check([PatternRefactorings::class], [$parsedPatterns, $patterns]);
+        try {
+            ForPsr4LoadedClasses::check([PatternRefactorings::class], [$parsedPatterns, $patterns]);
+        } catch (ErrorException $e) {
+            $this->error(' - No pattern found');
+        }
+
         $this->getOutput()->writeln(' - Finished search/replace');
 
         return $errorPrinter->hasErrors() ? 1 : 0;


### PR DESCRIPTION
When search_replace.php created in root project after run ```php artisan search_replace``` show ```Undefined array key 0``` error.
![2022-07-23_15-31-32](https://user-images.githubusercontent.com/98118400/180602769-f3bc2c73-7311-4d61-8f40-4a825ae6c942.png)
![2022-07-23_15-40-50](https://user-images.githubusercontent.com/98118400/180602774-a6e41abd-025d-41ff-90be-f132a08f9204.png)
