### PR TITLE
fixed bug in check:imports

### DIFF
--- a/src/CheckClassReferencesAreValid.php
+++ b/src/CheckClassReferencesAreValid.php
@@ -12,6 +12,7 @@ use Imanghafoori\TokenAnalyzer\ClassReferenceFinder;
 use Imanghafoori\TokenAnalyzer\ClassRefExpander;
 use Imanghafoori\TokenAnalyzer\GetClassProperties;
 use Imanghafoori\TokenAnalyzer\ParseUseStatement;
+use RuntimeException;
 
 class CheckClassReferencesAreValid
 {
@@ -211,7 +212,7 @@ class CheckClassReferencesAreValid
             [$classReferences, $hostNamespace,] = ClassRefExpander::expendReferences($classes, $imports, $namespace);
 
             return [$classReferences, $hostNamespace, $unusedRefs, $docblockRefs];
-        } catch (ErrorException $e) {
+        } catch (ErrorException | RuntimeException $e) {
             self::requestIssue($absFilePath);
 
             return [[], '', []];

--- a/src/CheckClassReferencesAreValid.php
+++ b/src/CheckClassReferencesAreValid.php
@@ -212,7 +212,11 @@ class CheckClassReferencesAreValid
             [$classReferences, $hostNamespace,] = ClassRefExpander::expendReferences($classes, $imports, $namespace);
 
             return [$classReferences, $hostNamespace, $unusedRefs, $docblockRefs];
-        } catch (ErrorException | RuntimeException $e) {
+        } catch (ErrorException $e) {
+            self::requestIssue($absFilePath);
+
+            return [[], '', []];
+        } catch (RuntimeException $e) {
             self::requestIssue($absFilePath);
 
             return [[], '', []];


### PR DESCRIPTION
phpdocumentor package throw a RuntimeException: 
A type is missing in an array expression

I added RuntimeException to catch so check:import does not failed.