### PR TITLE
test: add test for migrationDirs method in LaravelPaths class

### DIFF
--- a/tests/LaravelPathsTest.php
+++ b/tests/LaravelPathsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Imanghafoori\LaravelMicroscope\Tests;
+
+use Imanghafoori\LaravelMicroscope\FileReaders\FilePath;
+use Imanghafoori\LaravelMicroscope\LaravelPaths\LaravelPaths;
+
+class LaravelPathsTest extends BaseTestClass
+{
+    /** @test */
+    public function get_migration_dirs()
+    {
+        $customPath = base_path('path/fake/migrations');
+        $vendorPath = base_path('vendor/path/to/fake/migrations');
+
+        app('migrator')->path($customPath);
+        app('migrator')->path($vendorPath);
+
+        $result = LaravelPaths::migrationDirs();
+
+        $expected = [
+            FilePath::normalize($customPath),
+            app()->databasePath('migrations'),
+        ];
+
+        $this->assertIsArray($result);
+        $this->assertEquals($expected, $result);
+        $this->assertCount(2, $result);
+    }
+}


### PR DESCRIPTION
This commit adds a test for the `migrationDirs` method in the `LaravelPaths` class. The test checks that the method returns an array containing custom migration paths and the default migration path in the correct order, excluding the vendor path.