### PR TITLE
Bug fix from reporter

### DIFF
--- a/src/Features/CheckImports/CheckImportReporter.php
+++ b/src/Features/CheckImports/CheckImportReporter.php
@@ -108,8 +108,9 @@ class CheckImportReporter
         foreach ($psr4 as $psr4Namespace => $psr4Paths) {
             foreach ($psr4Paths as $path => $countClasses) {
                 $countClasses = str_pad((string) $countClasses, 3, ' ', STR_PAD_LEFT);
-                $len = strlen($psr4Namespace);
-                $result .= self::hyphen().'<fg=red>'.$psr4Namespace.str_repeat(' ', $spaces - $len).' </>';
+                $indentationLen = $spaces - strlen($psr4Namespace);
+                $indentationLen = max($indentationLen, 1);
+                $result .= self::hyphen().'<fg=red>'.$psr4Namespace.str_repeat(' ', $indentationLen).' </>';
                 $result .= " <fg=blue>$countClasses </>file".($countClasses == 1 ? '' : 's').' found (<fg=green>./'.$path."</>)\n";
             }
         }


### PR DESCRIPTION
```
 str_repeat(): Argument #2 ($times) must be greater than or equal to 0

  at laravel-microscope/src/Features/CheckImports/CheckImportReporter.php:112
    108▕         foreach ($psr4 as $psr4Namespace => $psr4Paths) {
    109▕             foreach ($psr4Paths as $path => $countClasses) {
    110▕                 $countClasses = str_pad((string) $countClasses, 3, ' ', STR_PAD_LEFT);
    111▕                 $len = strlen($psr4Namespace);
  ➜ 112▕                 $result .= self::hyphen().''.$psr4Namespace.str_repeat(' ', $spaces - $len).' ';
    113▕                 $result .= " $countClasses file".($countClasses == 1 ? '' : 's').' found (./'.$path.")\n";
    114▕             }
    115▕         }
    116▕ 

  1   laravel-microscope/src/Features/CheckImports/CheckImportReporter.php:112

  2   laravel-microscope/src/Features/CheckImports/CheckImportReporter.php:90
      Imanghafoori\LaravelMicroscope\Features\CheckImports\CheckImportReporter::formatPsr4Stats()
```