### PR TITLE
moved log after can run

### DIFF
--- a/src/Iterators/ChecksOnPsr4Classes.php
+++ b/src/Iterators/ChecksOnPsr4Classes.php
@@ -22,7 +22,7 @@ class ChecksOnPsr4Classes
     private static $checker;
 
     /**
-     * @param $checker
+     * @param  $checker
      * @return array<string, \Generator>
      */
     public static function apply($checker)
@@ -55,7 +55,7 @@ class ChecksOnPsr4Classes
     private static function processPaths($psr4Namespace, $psr4Paths)
     {
         foreach ((array) $psr4Paths as $psr4Path) {
-            $filesCount = (self::$checker)->applyChecksInPath($psr4Namespace, $psr4Path);
+            $filesCount = self::$checker->applyChecksInPath($psr4Namespace, $psr4Path);
             self::$checkedFilesCount += $filesCount;
 
             yield $psr4Path => $filesCount;

--- a/src/LaravelMicroscopeServiceProvider.php
+++ b/src/LaravelMicroscopeServiceProvider.php
@@ -25,11 +25,11 @@ class LaravelMicroscopeServiceProvider extends ServiceProvider
 
     public function boot()
     {
-        UnusedVarsInstaller::spyView();
-
         if (! $this->canRun()) {
             return;
         }
+
+        UnusedVarsInstaller::spyView();
 
         $this->addCacheStore();
 


### PR DESCRIPTION
if the microscope is not enabled, logs will conflict with Log assertions in PHPUnit and reduce the application's testability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Adjusted the execution flow of the spying mechanism to ensure it only activates when conditions are met, improving efficiency and preventing unnecessary operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->