### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -894,4 +894,4 @@ This project exists thanks to all the people who contribute. [[Contributors](htt
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=imanghafoori1/laravel-microscope&type=Date)](https://star-history.com/#imanghafoori1/laravel-microscope&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=imanghafoori1/laravel-microscope&type=Date)](https://star-history.dera.page/#imanghafoori1/laravel-microscope&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken because the GitHub stargazer API restricts the data source we relied on. This change points the chart to an alternative source that requires no API token, so the chart is rendered correctly again.

No other part of the README or badges is affected.

## Summary by Sourcery

Documentation:
- Point the README star history chart image and link to a reliable alternative provider to restore the chart display.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History chart image and link to use the new Star History service URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->